### PR TITLE
Add ESLint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,6 @@ export default [
     rules: {
       ...tseslint.configs.recommended.rules,
       ...importPlugin.configs.recommended.rules,
-      ...(importPlugin.configs.electron?.rules || {}),
       ...(importPlugin.configs.typescript?.rules || {}),
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      import: importPlugin,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      ...importPlugin.configs.recommended.rules,
+      ...(importPlugin.configs.electron?.rules || {}),
+      ...(importPlugin.configs.typescript?.rules || {}),
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add a new `eslint.config.js` for ESLint v9 flat configuration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863fd3253e88327a95a8b435395b39f