### PR TITLE
Fix devtools opening in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,10 @@ const createWindow = (): void => {
   // and load the index.html of the app.
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools();
+  // Open the DevTools only during development.
+  if (process.env.NODE_ENV !== "production") {
+    mainWindow.webContents.openDevTools();
+  }
 
   // IPC handlers para controles de ventana
   ipcMain.handle("window-minimize", () => {


### PR DESCRIPTION
## Summary
- open Electron devtools only when `NODE_ENV` is not `production`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686403ec48448327a691a51d562f89b9