### PR TITLE
Enable ESM modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "productName": "PDFai",
   "version": "1.0.0",
   "description": "Chatea con tus documentos PDF",
+  "type": "module",
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",


### PR DESCRIPTION
## Summary
- configure Node to treat `.js` files as ES modules by adding `"type": "module"` to `package.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686425f06cbc832797166e4d94e91078