### PR TITLE
Update README for linting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Sigue estos pasos para ejecutar el proyecto en tu máquina local.
     npm start
     ```
 
+## 🧹 Linting del Código
+
+Para mantener un estilo de código consistente se utiliza **ESLint**. Primero instala las dependencias:
+
+```bash
+npm install
+```
+
+Luego ejecuta el lint:
+
+```bash
+npm run lint
+```
+
+ESLint usa la configuración plana definida en `eslint.config.js`.
+
 ## 🤝 Contribuciones
 
 ¡Las contribuciones son bienvenidas! Si deseas contribuir, por favor revisa nuestra guía de commits para mantener un historial limpio y consistente.


### PR DESCRIPTION
## Summary
- document how to run ESLint
- mention `eslint.config.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686425f2168483279b1dc54652f7c841